### PR TITLE
Enable control port for Tor clients

### DIFF
--- a/torrc_templates/client.tmpl
+++ b/torrc_templates/client.tmpl
@@ -1,5 +1,7 @@
 ${include:common.i}
 SocksPort $socksport
+ControlPort $controlport
+CookieAuthentication 1
 
 #NOTE: Setting TestingClientConsensusDownloadSchedule doesn't
 #      help -- dl_stats.schedule is not DL_SCHED_CONSENSUS


### PR DESCRIPTION
I'd like to be able to use chutney to perform integration testing for OnionBalance. I need access to a client's Tor control port.
